### PR TITLE
Require SSE4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.1.0
+
+- Require SSE4.1 on x86_64
+- Use fast math optimizations on non-Windows platforms
+
 ## 3.0.1
 
 - Set C++ std version for non-Linux OSes

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ _SRC_DIR = _DIR / "src"
 _GGML_DIR = _SRC_DIR / "ggml"
 _GGML_SRC_DIR = _GGML_DIR / "src"
 
-version = "3.0.1"
+version = "3.1.0"
 
 # -----------------------------------------------------------------------------
 
@@ -111,8 +111,22 @@ if os.name == "nt":
     libraries = ["advapi32"]  # for Reg* crap
 else:
     # Assume GCC/Clang on Linux/MacOS
-    extra_compile_args = ["-O3", "-Wno-unused-function"]
+    extra_compile_args = [
+        "-O3",
+        "-Wno-unused-function",
+        "-ffast-math",
+        "-fno-math-errno",
+        "-fno-finite-math-only",
+    ]
     libraries = []
+
+    if arch == "x86":
+        # Assume SSE4.2 baseline
+        extra_compile_args += [
+            "-msse4.2",  # enables SSE2/SSE3/SSSE3/SSE4.1 as well
+            "-mpopcnt",  # part of the de-facto x86-64-v2 baseline
+            "-mtune=generic",  # good across Intel/AMD
+        ]
 
 ext_modules = [
     Extension(


### PR DESCRIPTION
- Require SSE4.1 on x86_64
- Use fast math optimizations on non-Windows platforms