### PR TITLE
Enable Half-Precision Floating Point on ARMv7 devices

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,9 @@ else:
             "-mtune=generic",  # good across Intel/AMD
         ]
 
+    if "armv7" in machine:
+        extra_compile_args += ["-mfp16-format=ieee"]
+
 ext_modules = [
     Extension(
         name="pysilero_vad.silero_vad",


### PR DESCRIPTION
I tried to build this on a Raspberry Pi2 (ARMv7) and it fails with
```
      g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -march=armv7-a -mfloat-abi=hard -mfpu=neon -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -march=armv7-a -mfloat-abi=hard -mfpu=neon -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -march=armv7-a -mfloat-abi=hard -mfpu=neon -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security -fstack-clash-protection -fPIC -DPy_LIMITED_API=0x03090000 -DVERSION_INFO=\"3.2.0\" -DGGML_VERSION=\"0.9.4\" -DGGML_COMMIT=\"19ceec8eac980403b714d603e5ca31653cd42a3f\" -DGGML_USE_CPU=1 -D_GNU_SOURCE=1 -DPOSIX_C_SOURCE=200809L -I/home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/include -I/home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/src -I/home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/src/ggml-cpu -I/home/user/tmp/vad/pysilero_vad-3.2.0/src -I/home/user/tmp/vad/pysilero_vad-3.2.0/.venv/include -I/usr/include/python3.13 -c src/ggml/src/ggml-cpu/amx/mmq.cpp -o build/temp.linux-armv7l-cpython-313/src/ggml/src/ggml-cpu/amx/mmq.o -O3 -Wno-unused-function -ffast-math -fno-math-errno -fno-finite-math-only -std=c++20
      In file included from src/ggml/src/ggml-cpu/amx/mmq.cpp:11:
      /home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/src/ggml-cpu/simd-mappings.h: In function ‘float neon_compute_fp16_to_fp32(ggml_fp16_t)’:
      /home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/src/ggml-cpu/simd-mappings.h:49:9: error: ‘__fp16’ was not declared in this scope; did you mean ‘__u16’?
         49 |         __fp16 tmp;
            |         ^~~~~~
            |         __u16
      /home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/src/ggml-cpu/simd-mappings.h:50:17: error: ‘tmp’ was not declared in this scope; did you mean ‘tm’?
         50 |         memcpy(&tmp, &h, sizeof(ggml_fp16_t));
            |                 ^~~
            |                 tm
      /home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/src/ggml-cpu/simd-mappings.h: In function ‘ggml_fp16_t neon_compute_fp32_to_fp16(float)’:
      /home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/src/ggml-cpu/simd-mappings.h:56:9: error: ‘__fp16’ was not declared in this scope; did you mean ‘__u16’?
         56 |         __fp16 tmp = f;
            |         ^~~~~~
            |         __u16
      /home/user/tmp/vad/pysilero_vad-3.2.0/src/ggml/src/ggml-cpu/simd-mappings.h:57:23: error: ‘tmp’ was not declared in this scope; did you mean ‘tm’?
         57 |         memcpy(&res, &tmp, sizeof(ggml_fp16_t));
            |                       ^~~
            |                       tm
      error: command '/usr/bin/g++' failed with exit code 1
```
Adding the compiler flag `-mfp16-format=ieee` sucessfully builds. According to https://stackoverflow.com/questions/31242106/fp16-type-undefined-in-gnu-arm-c this is default for AArch64 but not for ARMv7.